### PR TITLE
Improve Socket classes for Windows

### DIFF
--- a/rct/Connection.cpp
+++ b/rct/Connection.cpp
@@ -56,7 +56,6 @@ void Connection::checkData()
         onDataAvailable(mSocketClient, std::forward<Buffer>(mSocketClient->takeBuffer()));
 }
 
-#ifndef _WIN32
 bool Connection::connectUnix(const Path &socketFile, int timeout)
 {
     assert(!mSocketClient);
@@ -81,7 +80,6 @@ bool Connection::connectUnix(const Path &socketFile, int timeout)
     }
     return true;
 }
-#endif
 
 bool Connection::connectTcp(const String &host, uint16_t port, int timeout)
 {

--- a/rct/Connection.h
+++ b/rct/Connection.h
@@ -37,9 +37,7 @@ public:
     void setSilent(bool on) { mSilent = on; }
     bool isSilent() const { return mSilent; }
 
-#ifndef _WIN32
     bool connectUnix(const Path &socketFile, int timeout = 0);
-#endif
     bool connectTcp(const String &host, uint16_t port, int timeout = 0);
 
     int pendingWrite() const;

--- a/rct/EventLoop.h
+++ b/rct/EventLoop.h
@@ -23,6 +23,7 @@
 #elif defined(HAVE_SELECT)
 #  ifdef _WIN32
 #    include <Winsock2.h>
+#    include <rct/WindowsSocketGlobalGuard.h>
 #  else
 #    include <sys/select.h>
 #  endif

--- a/rct/Process_Windows.cpp
+++ b/rct/Process_Windows.cpp
@@ -406,3 +406,29 @@ String Process::errorString() const
     std::lock_guard<std::mutex> lock(mMutex);
     return mErrorString;
 }
+
+// Values for the second argument to access.
+// These may be OR'd together.
+#define R_OK    4       // Test for read permission.
+#define W_OK    2       // Test for write permission.
+// #define X_OK    1       // Test for execute permission - unsupported in windows
+#define F_OK    0       // Test for existence.
+Path Process::findCommand(const String &command, const char *path)
+{
+    /// @todo use Path::isAbsolute() and check if the file actually exists
+    if (command.isEmpty() || command.at(0) == '/')
+        return command;
+
+    if (!path)
+        path = getenv("PATH");
+    if (!path)
+        return Path();
+    bool ok;
+    const List<String> paths = String(path).split(':');
+    for (List<String>::const_iterator it = paths.begin(); it != paths.end(); ++it) {
+        const Path ret = Path::resolved(command, Path::RealPath, *it, &ok);
+        if (ok && !_access(ret.nullTerminated(), R_OK))
+            return ret;
+    }
+    return Path();
+}

--- a/rct/SocketClient.cpp
+++ b/rct/SocketClient.cpp
@@ -273,6 +273,16 @@ bool SocketClient::connect(const String& path)
     }
     return true;
 }
+#else
+bool SocketClient::connect(const String& path)
+{
+    Path p = path;
+    String s = p.readAll();
+    unsigned long port = s.toULong();
+    bool r = connect("127.0.0.1", port);
+    socketMode = Unix;
+    return r;
+}
 #endif
 
 bool SocketClient::bind(uint16_t port)
@@ -359,7 +369,7 @@ void SocketClient::setMulticastTTL(unsigned char ttl)
 }
 
 #ifdef _WIN32
-typedef int (*GetNameFunc)(SOCKET, sockaddr*, socklen_t*);
+typedef int (WINAPI *GetNameFunc)(SOCKET, sockaddr*, socklen_t*);
 #else
 typedef int (*GetNameFunc)(int, sockaddr*, socklen_t*);
 #endif

--- a/rct/SocketClient.h
+++ b/rct/SocketClient.h
@@ -32,9 +32,7 @@ public:
     enum State { Disconnected, Connecting, Connected };
     State state() const { return socketState; }
     unsigned int mode() const { return socketMode; }
-#ifndef _WIN32
     bool connect(const String& path); // UNIX
-#endif
     bool connect(const String& host, uint16_t port); // TCP
     bool bind(uint16_t port); // UDP
 

--- a/rct/SocketServer.h
+++ b/rct/SocketServer.h
@@ -44,10 +44,8 @@ public:
 
     void close();
     bool listen(uint16_t port, Mode mode = IPv4); // TCP
-#ifndef _WIN32
-    bool listen(const Path &path); // UNIX
-    bool listenFD(int fd);         // UNIX
-#endif
+    bool listen(const Path &path); // UNIX, fallback to TCP on Windows
+    bool listenFD(int fd);         // UNIX, always failed on Windows
     bool isListening() const { return fd != -1; }
 
     /**

--- a/rct/String.h
+++ b/rct/String.h
@@ -1,5 +1,13 @@
-#ifndef String_h
-#define String_h
+#ifndef STRING_H
+#define STRING_H
+
+#if defined(__MINGW32__) && defined(__USE_MINGW_ANSI_STDIO) && defined(__MINGW_PRINTF_FORMAT)
+#  define RCT_PRINTF_WARNING(fmt, firstarg) __attribute__ ((__format__ (__MINGW_PRINTF_FORMAT, fmt, firstarg)))
+#elif defined(_WIN32)
+#  define RCT_PRINTF_WARNING(fmt, firstarg)
+#else
+#  define RCT_PRINTF_WARNING(fmt, firstarg) __attribute__ ((__format__ (__printf__, fmt, firstarg)))
+#endif
 
 #include <errno.h>
 #include <ctype.h>
@@ -14,17 +22,6 @@
 
 #include <rct/List.h>
 
-#ifdef __MINGW32__
-    // Mingw does not supply its own runtime environment, but uses the one
-    // supplied by windows (msvcrt).
-    // Msvcrt used to not support the "long long" format specifiers, so mingw
-    // issues a warning when such a specifier is used.
-    // Newer versions of the msvcrt *do* support the specifiers however, so the
-    // warning is useless.
-#  define RCT_PRINTF_WARNING(fmt, firstarg)
-#else
-#  define RCT_PRINTF_WARNING(fmt, firstarg) __attribute__ ((__format__ (__printf__, fmt, firstarg)))
-#endif
 class String
 {
 public:

--- a/rct/WindowsSocketGlobalGuard.cpp
+++ b/rct/WindowsSocketGlobalGuard.cpp
@@ -1,0 +1,2 @@
+#include <rct/WindowsSocketGlobalGuard.h>
+WindowsSocketGuard WindowsSocketGlobalGuard::mGuard;

--- a/rct/WindowsSocketGlobalGuard.h
+++ b/rct/WindowsSocketGlobalGuard.h
@@ -1,0 +1,15 @@
+#ifndef WINDOWSSOCKETGLOBALGUARD_H
+#define WINDOWSSOCKETGLOBALGUARD_H
+
+#include <rct/WindowsSocketGuard.h>
+
+struct WindowsSocketGlobalGuard
+{
+    typedef WindowsSocketGuard::value_type value_type;
+    static WindowsSocketGuard mGuard;
+    value_type & get() {
+        return mGuard.get();
+    }
+};
+
+#endif // WINDOWSSOCKETGLOBALGUARD_H

--- a/rct/WindowsSocketGuard.h
+++ b/rct/WindowsSocketGuard.h
@@ -1,0 +1,23 @@
+#ifndef WINDOWSSOCKETGUARD_H
+#define WINDOWSSOCKETGUARD_H
+
+#include <Winsock2.h>
+
+struct WindowsSocketGuard
+{
+    WSADATA mData;
+    typedef WSADATA value_type;
+    WindowsSocketGuard()
+    {
+        ::WSAStartup(MAKEWORD(2, 2), &mData);
+    }
+    ~WindowsSocketGuard()
+    {
+        ::WSACleanup();
+    }
+    value_type & get() {
+        return mData;
+    }
+};
+
+#endif // WINDOWSSOCKETGUARD_H


### PR DESCRIPTION
* New class ``WindowsSocketGlobalGuard``

    Automatically invoke ``WSAStartup`` on program start, and ``WSACleanup`` on
    program exit.

* Add implementation for unix domain socket on Windows

  - ``bool connectUnix(const Path &socketFile, int timeout = 0)``
  - ``bool SocketServer::listen(const Path& path)``
  - ``bool SocketClient::connect(const String& path)``
  - ``bool SocketServer::listenFD(int fd)``

    note that ``listenFD`` always fails on Windows (for now).

* Implement ``Process::findCommand``

    file: rct/Process_Windows.h

* Improve ``RCT_PRINTF_WARNING`` on MinGW

    Use ```__MINGW_PRINTF_FORMAT``` if defined.

    file: rct/String.h

